### PR TITLE
fix : update ChromeDriver options for Heroku environment

### DIFF
--- a/selixir/driver.py
+++ b/selixir/driver.py
@@ -12,7 +12,7 @@ import time
 import platform
 import logging
 import uuid
-from typing import List, Optional, Union, Literal, Any, Callable, TypeVar, cast
+from typing import List, Optional, Union, TypeVar
 
 # Configure the logger
 logger = logging.getLogger("selixir")
@@ -225,7 +225,7 @@ def driver_start(url: str, heroku_mode: Union[bool, str] = False) -> webdriver.C
         unique_user_data_dir = f"/tmp/selenium_profile_{uuid.uuid4()}"
 
         logger.info("Starting ChromeDriver with Heroku environment settings.")
-        options.add_argument("--headless=new")
+        options.add_argument("--headless")
         options.add_argument("--disable-gpu")
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-setuid-sandbox")


### PR DESCRIPTION
This pull request includes changes to the `selixir/driver.py` file to simplify type imports and update ChromeDriver options for Heroku environment settings.

Codebase simplification:

* [`selixir/driver.py`](diffhunk://#diff-6a5450337a1bb5b2c1774b2dfee96391e734df89c086339d44d785f5af49f7b1L15-R15): Removed unused imports `Literal` and `Any` from the typing module.

Heroku environment settings update:

* [`selixir/driver.py`](diffhunk://#diff-6a5450337a1bb5b2c1774b2dfee96391e734df89c086339d44d785f5af49f7b1L228-R228): Modified the ChromeDriver options by changing the `--headless=new` argument to `--headless` to ensure compatibility with the Heroku environment.